### PR TITLE
Changed from the latest ubuntu version to 20.04 in dockerfiles

### DIFF
--- a/dockerfile.celery_email_worker
+++ b/dockerfile.celery_email_worker
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockerfile.celery_job_worker
+++ b/dockerfile.celery_job_worker
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockerfile.web
+++ b/dockerfile.web
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Changed from the latest ubuntu version to 20.04 in dockerfiles because of compatibility issues with the newest release of ubuntu 22.04